### PR TITLE
add reset sequence to copy db script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ INTEGRATION_TEST_PACKAGES ?= $(shell go list ./... | grep integration-tests )
 ORCH_SERVICES = tx-sender tx-listener api key-manager
 ORCH_MIGRATE = api key-manager
 DEPS_VAULT = vault vault-init vault-agent
-DEPS_POSTGRES = postgres-api postgres-old
+DEPS_POSTGRES = postgres-api
 DEPS_KAFKA = zookeeper kafka
 
 UNAME_S := $(shell uname -s)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ INTEGRATION_TEST_PACKAGES ?= $(shell go list ./... | grep integration-tests )
 ORCH_SERVICES = tx-sender tx-listener api key-manager
 ORCH_MIGRATE = api key-manager
 DEPS_VAULT = vault vault-init vault-agent
-DEPS_POSTGRES = postgres-api
+DEPS_POSTGRES = postgres-api postgres-old
 DEPS_KAFKA = zookeeper kafka
 
 UNAME_S := $(shell uname -s)

--- a/cmd/api/scripts/migrate-api-db.go
+++ b/cmd/api/scripts/migrate-api-db.go
@@ -116,6 +116,12 @@ func importFromFile(apiDB *pg.DB, tableName string) error {
 		return err
 	}
 
+	// Sync the auto-increment primary key
+	_, err = apiDB.Exec(fmt.Sprintf("SELECT setval('%s_id_seq', COALESCE((SELECT MAX(id)+1 FROM %s), 1), false)", tableName, tableName))
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Serial sequence for primary key gets out of sync when copying the DB. This fixes the issue by setting the auto-increment values to the MAX(id).